### PR TITLE
chore: move Lighting:GetAttribute calls into a connections

### DIFF
--- a/src-build/Components/BoneTree.lua
+++ b/src-build/Components/BoneTree.lua
@@ -212,8 +212,9 @@ function Class.new(RootBone: Bone, RootPart: BasePart): IBoneTree
 
 	if Settings.MatchWorkspaceWind then
 		self.GlobalWindConnection = workspace:GetPropertyChangedSignal("GlobalWind"):Connect(function()
-			Settings.WindDirection = SafeUnit(workspace.GlobalWind)
-			Settings.WindSpeed = workspace.GlobalWind.Magnitude
+			local GlobalWind = workspace.GlobalWind
+			Settings.WindDirection = SafeUnit(GlobalWind)
+			Settings.WindSpeed = GlobalWind.Magnitude
 		end)
 	else
 		self.WindDirectionConnection = Lighting:GetAttributeChangedSignal("WindDirection"):ConnectParallel(function()

--- a/src-build/Components/BoneTree.lua
+++ b/src-build/Components/BoneTree.lua
@@ -166,8 +166,9 @@ Class.__index = Class
 --- @within BoneTree
 --- @param RootBone Bone
 --- @param RootPart BasePart
+--- @param Settings {any}
 --- @return BoneTree
-function Class.new(RootBone: Bone, RootPart: BasePart): IBoneTree
+function Class.new(RootBone: Bone, RootPart: BasePart, Settings: {any}): IBoneTree
 	local self = setmetatable({
 		WindOffset = WIND_RNG:NextNumber(0, 1e6),
 		Root = RootBone:IsA("Bone") and RootBone or nil,
@@ -191,8 +192,6 @@ function Class.new(RootBone: Bone, RootPart: BasePart): IBoneTree
 		ObjectAcceleration = Vector3.zero,
 		ObjectPreviousPosition = RootPart.Position,
 	}, Class)
-
-	local Settings = self.Settings
 
 	self.InWorkspace = RootPart:IsDescendantOf(workspace)
 

--- a/src-build/Components/BoneTree.lua
+++ b/src-build/Components/BoneTree.lua
@@ -294,6 +294,28 @@ local RootPartCFrame = self.RootPart.CFrame
 do end
 end
 
+local WindDirection = Lighting:GetAttribute("WindDirection") or DefaultObjectSettings.WindDirection
+local WindSpeed = Lighting:GetAttribute("WindSpeed") or DefaultObjectSettings.WindSpeed
+local WindStrength = Lighting:GetAttribute("WindStrength") or DefaultObjectSettings.WindStrength
+
+if Lighting:GetAttribute("WindDirection") then
+	Lighting:GetAttributeChangedSignal("WindDirection"):Connect(function()
+		WindDirection = Lighting:GetAttribute("WindDirection")
+	end)
+end
+
+if Lighting:GetAttribute("WindSpeed") then
+	Lighting:GetAttributeChangedSignal("WindSpeed"):Connect(function()
+		WindDirection = Lighting:GetAttribute("WindSpeed")
+	end)
+end
+
+if Lighting:GetAttribute("WindStrength") then
+	Lighting:GetAttributeChangedSignal("WindStrength"):Connect(function()
+		WindDirection = Lighting:GetAttribute("WindStrength")
+	end)
+end
+
 --- @within BoneTree
 --- @param Delta number -- Δt
 --- Calculates forces and updates wind. Also calls Bone:StepPhysics()
@@ -307,14 +329,9 @@ local Settings = self.Settings
 		Settings.WindDirection = SafeUnit(GlobalWind)
 		Settings.WindSpeed = GlobalWind.Magnitude
 	else
-		local WindDirection = Lighting:GetAttribute("WindDirection") or DefaultObjectSettings.WindDirection
-		local WindSpeed = Lighting:GetAttribute("WindSpeed") or DefaultObjectSettings.WindSpeed
-
 		Settings.WindDirection = SafeUnit(WindDirection)
 		Settings.WindSpeed = WindSpeed
 	end
-
-	local WindStrength = Lighting:GetAttribute("WindStrength") or DefaultObjectSettings.WindStrength
 
 	Settings.WindStrength = WindStrength
 

--- a/src-build/Components/BoneTree.lua
+++ b/src-build/Components/BoneTree.lua
@@ -192,6 +192,8 @@ function Class.new(RootBone: Bone, RootPart: BasePart): IBoneTree
 		ObjectPreviousPosition = RootPart.Position,
 	}, Class)
 
+	local Settings = self.Settings
+
 	self.InWorkspace = RootPart:IsDescendantOf(workspace)
 
 	-- TODO: Revisit optimising :IsDescendantOf calls
@@ -205,8 +207,27 @@ function Class.new(RootBone: Bone, RootPart: BasePart): IBoneTree
 
 	self.AttributeConnection = RootPart.AttributeChanged:ConnectParallel(function(Attribute)
 		-- No need validating
-		self.Settings[Attribute] = RootPart:GetAttribute(Attribute) or DefaultObjectSettings[Attribute]
+		Settings[Attribute] = RootPart:GetAttribute(Attribute) or DefaultObjectSettings[Attribute]
 	end)
+
+	if Settings.MatchWorkspaceWind then
+		self.GlobalWindConnection = workspace:GetPropertyChangedSignal("GlobalWind"):Connect(function()
+			Settings.WindDirection = SafeUnit(workspace.GlobalWind)
+			Settings.WindSpeed = workspace.GlobalWind.Magnitude
+		end)
+	else
+		self.WindDirectionConnection = Lighting:GetAttributeChangedSignal("WindDirection"):ConnectParallel(function()
+			Settings.WindDirection = Lighting:GetAttribute("WindDirection")
+		end)
+	
+		self.WindSpeedConnnection = Lighting:GetAttributeChangedSignal("WindSpeed"):ConnectParallel(function()
+			Settings.WindSpeed = Lighting:GetAttribute("WindSpeed")
+		end)
+	
+		self.WindStrengthConnection = Lighting:GetAttributeChangedSignal("WindStrength"):ConnectParallel(function()
+			Settings.WindStrength = Lighting:GetAttribute("WindStrength")
+		end)
+	end
 
 	return self :: IBoneTree
 end
@@ -294,28 +315,6 @@ local RootPartCFrame = self.RootPart.CFrame
 do end
 end
 
-local WindDirection = Lighting:GetAttribute("WindDirection") or DefaultObjectSettings.WindDirection
-local WindSpeed = Lighting:GetAttribute("WindSpeed") or DefaultObjectSettings.WindSpeed
-local WindStrength = Lighting:GetAttribute("WindStrength") or DefaultObjectSettings.WindStrength
-
-if Lighting:GetAttribute("WindDirection") then
-	Lighting:GetAttributeChangedSignal("WindDirection"):Connect(function()
-		WindDirection = Lighting:GetAttribute("WindDirection")
-	end)
-end
-
-if Lighting:GetAttribute("WindSpeed") then
-	Lighting:GetAttributeChangedSignal("WindSpeed"):Connect(function()
-		WindDirection = Lighting:GetAttribute("WindSpeed")
-	end)
-end
-
-if Lighting:GetAttribute("WindStrength") then
-	Lighting:GetAttributeChangedSignal("WindStrength"):Connect(function()
-		WindDirection = Lighting:GetAttribute("WindStrength")
-	end)
-end
-
 --- @within BoneTree
 --- @param Delta number -- Δt
 --- Calculates forces and updates wind. Also calls Bone:StepPhysics()
@@ -323,17 +322,6 @@ function Class:StepPhysics(Delta: number)
 do end	
 local Settings = self.Settings
 	local Force = (Settings.Gravity + Settings.Force) * Delta
-
-	if Settings.MatchWorkspaceWind == true then
-		local GlobalWind = workspace.GlobalWind
-		Settings.WindDirection = SafeUnit(GlobalWind)
-		Settings.WindSpeed = GlobalWind.Magnitude
-	else
-		Settings.WindDirection = SafeUnit(WindDirection)
-		Settings.WindSpeed = WindSpeed
-	end
-
-	Settings.WindStrength = WindStrength
 
 	for _, Bone in self.Bones do
 		Bone:StepPhysics(self, Force, Delta)
@@ -503,6 +491,14 @@ function Class:Destroy()
 	task.synchronize()
 	self.DestroyConnection:Disconnect()
 	self.AttributeConnection:Disconnect()
+
+	if self.Settings.MatchWorkspaceWind then
+		self.GlobalWindConnection:Disconnect()
+	else
+		self.WindDirectionConnection:Disconnect()
+		self.WindSpeedConnection:Disconnect()
+		self.WindStrengthConnection:Disconnect()
+	end
 
 	for _, Bone in self.Bones do
 		Bone:Destroy()

--- a/src-build/init.lua
+++ b/src-build/init.lua
@@ -133,10 +133,7 @@ end
 --- :::
 --- Creates a bone tree from the RootPart and RootBone and then adds all child bones via m_AppendBone
 function Class:m_CreateBoneTree(RootPart: BasePart, RootBone: Bone)
-	local Settings = Utilities.GatherObjectSettings(RootPart)
-	local BoneTree = BoneTreeClass.new(RootBone, RootPart)
-
-	BoneTree.Settings = Settings
+	local BoneTree = BoneTreeClass.new(RootBone, RootPart, Utilities.GatherObjectSettings(RootPart))
 
 	SB_VERBOSE_LOG(`Creating bone tree {RootPart.Name}; {RootBone.Name}`)
 	SB_INDENT_LOG()

--- a/src/Components/BoneTree.lua
+++ b/src/Components/BoneTree.lua
@@ -166,15 +166,16 @@ Class.__index = Class
 --- @within BoneTree
 --- @param RootBone Bone
 --- @param RootPart BasePart
+--- @param Settings {any}
 --- @return BoneTree
-function Class.new(RootBone: Bone, RootPart: BasePart): IBoneTree
+function Class.new(RootBone: Bone, RootPart: BasePart, Settings: {any}): IBoneTree
 	local self = setmetatable({
 		WindOffset = WIND_RNG:NextNumber(0, 1e6),
 		Root = RootBone:IsA("Bone") and RootBone or nil,
 		RootPart = RootPart,
 		RootPartSize = RootPart.Size,
 		Bones = {},
-		Settings = {},
+		Settings = Settings,
 		UpdateRate = 0,
 		InView = true,
 		AccumulatedDelta = 0,
@@ -191,8 +192,6 @@ function Class.new(RootBone: Bone, RootPart: BasePart): IBoneTree
 		ObjectAcceleration = Vector3.zero,
 		ObjectPreviousPosition = RootPart.Position,
 	}, Class)
-
-	local Settings = self.Settings
 
 	self.InWorkspace = RootPart:IsDescendantOf(workspace)
 

--- a/src/Components/BoneTree.lua
+++ b/src/Components/BoneTree.lua
@@ -212,8 +212,9 @@ function Class.new(RootBone: Bone, RootPart: BasePart): IBoneTree
 
 	if Settings.MatchWorkspaceWind then
 		self.GlobalWindConnection = workspace:GetPropertyChangedSignal("GlobalWind"):Connect(function()
-			Settings.WindDirection = SafeUnit(workspace.GlobalWind)
-			Settings.WindSpeed = workspace.GlobalWind.Magnitude
+			local GlobalWind = workspace.GlobalWind
+			Settings.WindDirection = SafeUnit(GlobalWind)
+			Settings.WindSpeed = GlobalWind.Magnitude
 		end)
 	else
 		self.WindDirectionConnection = Lighting:GetAttributeChangedSignal("WindDirection"):ConnectParallel(function()

--- a/src/Components/BoneTree.lua
+++ b/src/Components/BoneTree.lua
@@ -294,6 +294,28 @@ function Class:PreUpdate(Delta: number)
 	debug.profileend()
 end
 
+local WindDirection = Lighting:GetAttribute("WindDirection") or DefaultObjectSettings.WindDirection
+local WindSpeed = Lighting:GetAttribute("WindSpeed") or DefaultObjectSettings.WindSpeed
+local WindStrength = Lighting:GetAttribute("WindStrength") or DefaultObjectSettings.WindStrength
+
+if Lighting:GetAttribute("WindDirection") then
+	Lighting:GetAttributeChangedSignal("WindDirection"):Connect(function()
+		WindDirection = Lighting:GetAttribute("WindDirection")
+	end)
+end
+
+if Lighting:GetAttribute("WindSpeed") then
+	Lighting:GetAttributeChangedSignal("WindSpeed"):Connect(function()
+		WindDirection = Lighting:GetAttribute("WindSpeed")
+	end)
+end
+
+if Lighting:GetAttribute("WindStrength") then
+	Lighting:GetAttributeChangedSignal("WindStrength"):Connect(function()
+		WindDirection = Lighting:GetAttribute("WindStrength")
+	end)
+end
+
 --- @within BoneTree
 --- @param Delta number -- Δt
 --- Calculates forces and updates wind. Also calls Bone:StepPhysics()
@@ -307,14 +329,9 @@ function Class:StepPhysics(Delta: number)
 		Settings.WindDirection = SafeUnit(GlobalWind)
 		Settings.WindSpeed = GlobalWind.Magnitude
 	else
-		local WindDirection = Lighting:GetAttribute("WindDirection") or DefaultObjectSettings.WindDirection
-		local WindSpeed = Lighting:GetAttribute("WindSpeed") or DefaultObjectSettings.WindSpeed
-
 		Settings.WindDirection = SafeUnit(WindDirection)
 		Settings.WindSpeed = WindSpeed
 	end
-
-	local WindStrength = Lighting:GetAttribute("WindStrength") or DefaultObjectSettings.WindStrength
 
 	Settings.WindStrength = WindStrength
 

--- a/src/init.lua
+++ b/src/init.lua
@@ -133,10 +133,7 @@ end
 --- :::
 --- Creates a bone tree from the RootPart and RootBone and then adds all child bones via m_AppendBone
 function Class:m_CreateBoneTree(RootPart: BasePart, RootBone: Bone)
-	local Settings = Utilities.GatherObjectSettings(RootPart)
-	local BoneTree = BoneTreeClass.new(RootBone, RootPart)
-
-	BoneTree.Settings = Settings
+	local BoneTree = BoneTreeClass.new(RootBone, RootPart, Utilities.GatherObjectSettings(RootPart))
 
 	SB_VERBOSE_LOG(`Creating bone tree {RootPart.Name}; {RootBone.Name}`)
 	SB_INDENT_LOG()


### PR DESCRIPTION
Moves Lighting:GetAttribute calls into their own connections. Stops updating every physics step. 