### PR TITLE
fix: Added disconnect to stop function

### DIFF
--- a/src-build/init.luau
+++ b/src-build/init.luau
@@ -639,7 +639,7 @@ function Class.Start(): { Stop: () -> () }
 		SB_UNINDENT_LOG()
 	end
 
-	CollectionService:GetInstanceAddedSignal("SmartBone"):Connect(SetupObject)
+	connection = CollectionService:GetInstanceAddedSignal("SmartBone"):Connect(SetupObject)
 
 	for _, Object in CollectionService:GetTagged("SmartBone") do
 		SetupObject(Object)
@@ -674,6 +674,11 @@ function Class.Start(): { Stop: () -> () }
 
 			for _, Actor: Actor in ActorFolder:GetChildren() do
 				Actor:SendMessage("Destroy")
+			end
+
+			if connection then
+				connection:Disconnect()
+				connection = nil
 			end
 		end,
 	}

--- a/src/init.luau
+++ b/src/init.luau
@@ -639,7 +639,7 @@ function Class.Start(): { Stop: () -> () }
 		SB_UNINDENT_LOG()
 	end
 
-	CollectionService:GetInstanceAddedSignal("SmartBone"):Connect(SetupObject)
+	connection = CollectionService:GetInstanceAddedSignal("SmartBone"):Connect(SetupObject)
 
 	for _, Object in CollectionService:GetTagged("SmartBone") do
 		SetupObject(Object)
@@ -674,6 +674,11 @@ function Class.Start(): { Stop: () -> () }
 
 			for _, Actor: Actor in ActorFolder:GetChildren() do
 				Actor:SendMessage("Destroy")
+			end
+
+			if connection then
+				connection:Disconnect()
+				connection = nil
 			end
 		end,
 	}


### PR DESCRIPTION
The disconnect makes it so any new SmartBone objects that were added to the workspace after the Stop() function is called don't start simulating