### PR TITLE
fix: Prevent creation of duplicate bone children

### DIFF
--- a/src-build/init.luau
+++ b/src-build/init.luau
@@ -152,7 +152,13 @@ function Class:m_CreateBoneTree(RootPart: BasePart, RootBone: Bone)
 				HasBoneChild = true
 			end
 		end
-
+		
+		if string.sub(Bone.Name,#Bone.Name-3,#Bone.Name) == "_end"
+		or string.sub(Bone.Name,#Bone.Name-4,#Bone.Name) == "_Tail"
+		then
+			HasBoneChild = true
+		end
+		
 		if not HasBoneChild then -- Add tail bone for transform calculations
 			SB_VERBOSE_LOG(`Adding tail bone`)
 			local Parent = Bone.Parent

--- a/src/init.luau
+++ b/src/init.luau
@@ -152,7 +152,13 @@ function Class:m_CreateBoneTree(RootPart: BasePart, RootBone: Bone)
 				HasBoneChild = true
 			end
 		end
-
+		
+		if string.sub(Bone.Name,#Bone.Name-3,#Bone.Name) == "_end"
+		or string.sub(Bone.Name,#Bone.Name-4,#Bone.Name) == "_Tail"
+		then
+			HasBoneChild = true
+		end
+		
 		if not HasBoneChild then -- Add tail bone for transform calculations
 			SB_VERBOSE_LOG(`Adding tail bone`)
 			local Parent = Bone.Parent


### PR DESCRIPTION
Checks for suffixes "_end" and "_Tail" in the name of a bone, then doesn't create child bone if there already is one of the aforementioned suffixes.

It also looks for an "_end" tail because Blender armatures might import into Roblox with a bone child already created with an "_end" suffix (if it was exported with that setting enabled) https://blender.stackexchange.com/questions/109972/fbx-export-bone-end