### PR TITLE
fix: Add yielding for required bones that may of not replicated yet

### DIFF
--- a/src/Dependencies/Config.luau
+++ b/src/Dependencies/Config.luau
@@ -12,6 +12,8 @@ return {
 	FAR_PLANE = 500,
 	-- Frequency of which we do frustum checks, 1 being every frame, 2 being every other frame, 3 being every 3rd frame and so on.
 	FRUSTUM_FREQ = 2,
+	-- Wait time for root bones that may of not replicated to the client yet.
+	ROOT_BONE_WAIT_TIME = 5,
 	-- Debug info in output, can lag the game.
 	LOG_VERBOSE = false,
 	-- Controls if we should reset bone positions when .Stop() is called

--- a/src/init.luau
+++ b/src/init.luau
@@ -358,6 +358,7 @@ function Class:LoadObject(Object: BasePart)
 		for Name, _ in RootBonesNotLoaded do
 			local Bone = Object:WaitForChild(Name, Config.ROOT_BONE_WAIT_TIME or 5)
 			if Bone and Bone:IsA("Bone") then
+				RootBonesNotLoaded[Bone.Name] = nil
 				Bones[Bone.Name] = Bone
 			end
 		end

--- a/src/init.luau
+++ b/src/init.luau
@@ -334,7 +334,13 @@ function Class:LoadObject(Object: BasePart)
 	end
 
 	local RootNames = RootAttribute:split(",")
+	local RootBonesNotLoaded = {}
 	local Bones = {}
+
+	-- Gather pre-recorded bones into table
+	for _, Name in RootNames do
+		RootBonesNotLoaded[Name] = true
+	end
 
 	-- Gather bones into table indexed with name
 	for _, Descendant in Object:QueryDescendants("Bone") do
@@ -343,7 +349,22 @@ function Class:LoadObject(Object: BasePart)
 			continue
 		end
 
+		RootBonesNotLoaded[Descendant.Name] = nil
 		Bones[Descendant.Name] = Descendant
+	end
+
+	-- Check for any missing bones
+	if next(RootBonesNotLoaded) then
+		for Name, _ in RootBonesNotLoaded do
+			local Bone = Object:WaitForChild(Name, Config.ROOT_BONE_WAIT_TIME or 5)
+			if Bone and Bone:IsA("Bone") then
+				Bones[Bone.Name] = Bone
+			end
+		end
+
+		if next(RootBonesNotLoaded) then
+			warn(`[SmartBone2::LoadObject] Couldn't find all roots defined {Object.Name}`)
+		end
 	end
 
 	-- Create bone trees


### PR DESCRIPTION
This hopefully fixes an issue where rigs cannot fully load due to bones not replicating soon enough.

Changes made:
- Added config `ROOT_BONE_WAIT_TIME` with default being `5` seconds.
- Added new table to track missing bones.
- Added a check for missing bones, which will then allow up to `ROOT_BONE_WAIT_TIME` set seconds to replicate.