### PR TITLE
AnchorsRotate Fixed + GravityFalloff Feature Implemented

### DIFF
--- a/dev.project.json
+++ b/dev.project.json
@@ -5,7 +5,7 @@
 
     "ReplicatedStorage": {
       "SmartBone": {
-        "$path": "src"
+        "$path": "src-build"
       }
     },
 

--- a/dev.project.json
+++ b/dev.project.json
@@ -5,7 +5,7 @@
 
     "ReplicatedStorage": {
       "SmartBone": {
-        "$path": "src-build"
+        "$path": "src"
       }
     },
 

--- a/docs/smartbone.md
+++ b/docs/smartbone.md
@@ -68,6 +68,8 @@ For example if you wanted more flowy wind you would have a medium wind speed wit
 
 - \[*Vector3*\] Gravity – Direction and Magnitude of Gravity in World Space.
 
+- \[*Number*\] GravityFalloff – Gravity will dampen based on how close the mesh's UpVector is to it's resting state. 0 being no damping and 1 being full damping.
+
 - \[*Vector3*\] Force – Additional Force applied to Bones in World Space. Supplementary to Gravity.
 
 - \[*String*\] Constraint - Option between Spring, Distance and Rope.

--- a/src/Components/Bone.luau
+++ b/src/Components/Bone.luau
@@ -453,8 +453,9 @@ function Class.new(Bone: Bone, RootBone: Bone, RootPart: BasePart): IBone
 		Radius = 0,
 		Friction = 0,
 		RotationLimit = 0,
-		Force = nil,
-		Gravity = nil,
+		Force = Vector3.zero,
+		Gravity = Vector3.zero,
+		GravityFalloff = 0,
 
 		SolvedAnimatedCFrame = false,
 		HasChild = false,
@@ -585,9 +586,10 @@ function Class:StepPhysics(BoneTree, Force: Vector3, Delta: number) -- Parallel 
 	-- Custom forces per bone
 	if self.Force or self.Gravity then
 		debug.profilebegin("Solve Force")
-		Force = (self.Gravity or BoneTree.Settings.Gravity)
 
-		Force = (Force + (self.Force or BoneTree.Settings.Force))
+		Force = (self.Gravity or BoneTree.Settings.Gravity)
+		Force += (self.Force or BoneTree.Settings.Force)
+
 		debug.profileend()
 	end
 
@@ -710,7 +712,7 @@ function Class:SolveTransform(BoneTree, Delta: number) -- Parallel safe
 		--elseif ShouldAverage then
 		--	ParentBone.RotationSum += Vector3.new(Rotation:ToEulerAnglesXYZ())
 		else
-			ParentBone.CalculatedWorldCFrame = BoneParent.WorldCFrame:Lerp(CFrame.new(ParentBone.Position) * Rotation, alpha)
+			ParentBone.CalculatedWorldCFrame = ReferenceCFrame:Lerp(CFrame.new(ParentBone.Position) * Rotation, alpha)
 			--ParentBone.CalculatedWorldCFrame = CFrame.new(ParentBone.Position) * Rotation
 		end
 
@@ -744,10 +746,12 @@ function Class:ApplyTransform(BoneTree)
 	-- end
 
 	if ParentBone and BoneParent then
-		if ParentBone.Anchored and not BoneTree.Settings.AnchorsRotate then -- Anchored and anchors do not rotate
-			BoneParent.WorldCFrame = ParentBone.TransformOffset
-		elseif ParentBone.Anchored then -- Anchored and anchors rotate
-			BoneParent.WorldCFrame = CFrame.new(ParentBone.Position) * ParentBone.CalculatedWorldCFrame.Rotation
+		if ParentBone.Anchored then -- Anchored and anchors do not rotate
+			if BoneTree.Settings.AnchorsRotate and not self.Anchored then
+				BoneParent.WorldCFrame = CFrame.new(ParentBone.Position) * ParentBone.CalculatedWorldCFrame.Rotation
+			else
+				BoneParent.WorldCFrame = ParentBone.TransformOffset
+			end			
 		else -- Not anchored
 			BoneParent.WorldCFrame = ParentBone.CalculatedWorldCFrame
 		end

--- a/src/Components/Bone.luau
+++ b/src/Components/Bone.luau
@@ -747,6 +747,7 @@ function Class:ApplyTransform(BoneTree)
 
 	if ParentBone and BoneParent then
 		if ParentBone.Anchored then -- Anchored and anchors do not rotate
+			
 			if BoneTree.Settings.AnchorsRotate and not self.Anchored then
 				BoneParent.WorldCFrame = CFrame.new(ParentBone.Position) * ParentBone.CalculatedWorldCFrame.Rotation
 			else

--- a/src/Components/BoneTree.luau
+++ b/src/Components/BoneTree.luau
@@ -38,6 +38,7 @@ export type IBoneTree = {
 	ObjectVelocity: Vector3,
 	ObjectAcceleration: Vector3,
 	ObjectPreviousPosition: Vector3,
+	DefaultRootOrientation: CFrame,
 }
 
 type ImOverlay = {
@@ -157,6 +158,10 @@ end
 --- @prop ObjectPreviousPosition Vector3
 --- Root parts previous position
 
+--- @within BoneTree
+--- @prop DefaultRootOrientation
+--- The Default WorldSpace Orientation of the Root Bone
+
 local Class = {}
 Class.__index = Class
 
@@ -188,6 +193,7 @@ function Class.new(RootBone: Bone, RootPart: BasePart, Settings: { any }): IBone
 		ObjectVelocity = Vector3.zero,
 		ObjectAcceleration = Vector3.zero,
 		ObjectPreviousPosition = RootPart.Position,
+		DefaultRootOrientation = (RootBone:IsA("Bone") and RootBone.WorldCFrame or CFrame.identity).Rotation,
 	}, Class)
 
 	self.InWorkspace = RootPart:IsDescendantOf(workspace)
@@ -327,7 +333,20 @@ end
 function Class:StepPhysics(Delta: number)
 	debug.profilebegin("BoneTree::StepPhysics")
 	local Settings = self.Settings
-	local Force = (Settings.Gravity + Settings.Force)
+
+	-- Calculate the effect of Gravity given deviation from the resting 'Skyward' UpVector and clamped by GravityFalloff Setting
+
+	local DefaultRot, NewRot = self.DefaultRootOrientation.Rotation, self.Root.WorldCFrame.Rotation
+	local Transform = NewRot:ToWorldSpace(DefaultRot)
+
+	local RelativeDotProduct = Transform.UpVector:Dot(Vector3.yAxis)
+
+	local DistanceFromWorldUp = math.clamp(1 - RelativeDotProduct, 0, 1)
+
+	local Gravity = Settings.Gravity
+	Gravity = Gravity * math.lerp((1 - Settings.GravityFalloff), 1, DistanceFromWorldUp)
+
+	local Force = (Gravity + Settings.Force)
 
 	if Settings.MatchWorkspaceWind == true then
 		local GlobalWind = workspace.GlobalWind

--- a/src/Dependencies/DefaultObjectSettings.luau
+++ b/src/Dependencies/DefaultObjectSettings.luau
@@ -12,6 +12,7 @@ return table.freeze({
 	Constraint = "Spring",
 	Force = Vector3.yAxis * FORCE_MULTIPLIER,
 	Gravity = -Vector3.yAxis * 25,
+	GravityFalloff = 0,
 
 	WindType = "Hybrid",
 	MatchWorkspaceWind = true,

--- a/src/Dependencies/Utilities.luau
+++ b/src/Dependencies/Utilities.luau
@@ -133,7 +133,7 @@ function module.GatherBoneSettings(Bone: Bone)
 		RotationLimit = RotationLimit,
 		Radius = Radius,
 		Force = Force,
-		Gravity = Gravity,
+		Gravity = Gravity
 	}
 
 	return Settings


### PR DESCRIPTION
I was able to fix anchors rotate by making the system only recognize anchors that have no anchored children as Rotate-able. This seems to have completely fixed the issue. I've also set up a Gravity Falloff feature using dot product of the orientation of the root bone relative to a positive yAxis value to get an alpha value that lerps then gravity between 0 and Settings.Gravity